### PR TITLE
Fix header case

### DIFF
--- a/src/Abstract_command.h
+++ b/src/Abstract_command.h
@@ -1,7 +1,7 @@
 
 #ifndef ABSTRACT_COMMAND_H_
 #define ABSTRACT_COMMAND_H_
-#include "command.h"
+#include "Command.h"
 
 namespace zathras::interface {
 	class Abstract_command : public Command

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "command.h"
+#include "Command.h"
 namespace zathras::interface {
 	Command::Command() {
 	}

--- a/src/Command.h
+++ b/src/Command.h
@@ -9,7 +9,7 @@
 #define COMMAND_H_
 #include <memory>
 
-#include "command_receiver.h"
+#include "Command_receiver.h"
 
 
 namespace zathras::interface {

--- a/src/Command_receiver.cpp
+++ b/src/Command_receiver.cpp
@@ -1,4 +1,4 @@
-#include "command_receiver.h"
+#include "Command_receiver.h"
 
 namespace zathras::interface {
 	Command_receiver::Command_receiver()

--- a/src/Info.cpp
+++ b/src/Info.cpp
@@ -1,5 +1,5 @@
-#include "info.h"
-#include "move.h"
+#include "Info.h"
+#include "Move.h"
 namespace zathras::interface {
 	int Info::seldepth = 0;
 	Move Info::currmove;

--- a/src/Info.h
+++ b/src/Info.h
@@ -2,7 +2,7 @@
 #include <deque>
 #include <chrono>
 
-#include "move.h"
+#include "Move.h"
 #include <iostream>
 
 namespace zathras::interface {

--- a/src/Perft_command.cpp
+++ b/src/Perft_command.cpp
@@ -5,7 +5,7 @@
  *      Author: nczempin
  */
 
-#include "perft_command.h"
+#include "Perft_command.h"
 
 #include <iostream>
 #include <memory>
@@ -13,8 +13,8 @@
 #include <vector>
 #include <ctime>
 
-#include "position.h"
-#include "move_generator.h"
+#include "Position.h"
+#include "Move_generator.h"
 #include <cassert>
 
 namespace zathras::interface {

--- a/src/Perft_command.h
+++ b/src/Perft_command.h
@@ -12,11 +12,11 @@
 #include <stack>
 
 
-#include "abstract_command.h"
-#include "command_receiver.h"
-#include "position.h"
-#include "move_generator.h"
-#include "move.h"
+#include "Abstract_command.h"
+#include "Command_receiver.h"
+#include "Position.h"
+#include "Move_generator.h"
+#include "Move.h"
 
 namespace zathras::interface {
 	class Perft_command : public Abstract_command {

--- a/src/Uci.h
+++ b/src/Uci.h
@@ -8,12 +8,12 @@
 #include <thread>
 
 
-#include "character.h"
-#include "position.h"
-#include "move_generator.h"
-#include "searcher.h"
-#include "move.h"
-#include "evaluator.h"
+#include "Character.h"
+#include "Position.h"
+#include "Move_generator.h"
+#include "Searcher.h"
+#include "Move.h"
+#include "Evaluator.h"
 
 #include "Info.h"
 #include "Perft_command.h"

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -1,4 +1,4 @@
-#include "info.h"
+#include "Info.h"
 void resetClock() {
 	zathras::interface::Info::start = chrono::system_clock::now();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 
 #include "zathras_lib.h"
-#include "uci.h"
+#include "Uci.h"
 
 
 using namespace std;

--- a/zathras_lib/src/Bitboard.cpp
+++ b/zathras_lib/src/Bitboard.cpp
@@ -5,12 +5,12 @@
  *      Author: nczempin
  */
 
-#include "bitboard.h"
+#include "Bitboard.h"
 #include "typedefs.h"
 #include <cassert>
 
 
-#include "move_generator.h" //TODO cyclic dependency
+#include "Move_generator.h" //TODO cyclic dependency
 
 
 namespace positions {

--- a/zathras_lib/src/Bitboard_test.cpp
+++ b/zathras_lib/src/Bitboard_test.cpp
@@ -6,7 +6,7 @@
  */
 #include <iostream>
 
-#include "bitboard.h"
+#include "Bitboard.h"
 #include "typedefs.h"
 
 namespace positions {

--- a/zathras_lib/src/Evaluator.h
+++ b/zathras_lib/src/Evaluator.h
@@ -3,7 +3,7 @@
 
 #include <algorithm>
 
-#include "position.h"
+#include "Position.h"
 
 #include "piece_count.h"
 namespace Eval {

--- a/zathras_lib/src/Move.h
+++ b/zathras_lib/src/Move.h
@@ -4,8 +4,8 @@
 #include <cstdint>
 
 #include "typedefs.h"
-#include "square.h"
-#include "piece.h"
+#include "Square.h"
+#include "Piece.h"
 #include "misc.h"
 
 namespace zathras_lib::moves {

--- a/zathras_lib/src/Move_container.cpp
+++ b/zathras_lib/src/Move_container.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 //#include <span>
 
-#include "move_container.h"
-#include "piece.h"
+#include "Move_container.h"
+#include "Piece.h"
 
 namespace zathras_lib::moves {
 

--- a/zathras_lib/src/Move_container.h
+++ b/zathras_lib/src/Move_container.h
@@ -8,7 +8,7 @@
 #ifndef MOVE_CONTAINER_H_
 #define MOVE_CONTAINER_H_
 
-#include "move.h"
+#include "Move.h"
 
 #include <stddef.h>
 #include <cstdint>

--- a/zathras_lib/src/Move_generator.cpp
+++ b/zathras_lib/src/Move_generator.cpp
@@ -5,16 +5,16 @@
  *      Author: nczempin
  */
 
-#include "move_generator.h"
+#include "Move_generator.h"
 
 #include <bitset>
 #include <utility>
 #include <vector>
 
-#include "position.h"
-#include "square.h"
-#include "piece.h"
-#include "bitboard.h"
+#include "Position.h"
+#include "Square.h"
+#include "Piece.h"
+#include "Bitboard.h"
 
 
 namespace zathras_lib::moves {

--- a/zathras_lib/src/Move_generator.h
+++ b/zathras_lib/src/Move_generator.h
@@ -8,9 +8,9 @@
 #ifndef MOVE_GENERATOR_H_
 #define MOVE_GENERATOR_H_
 
-#include "position.h"
-#include "move.h"
-#include "move_container.h"
+#include "Position.h"
+#include "Move.h"
+#include "Move_container.h"
 
 namespace zathras_lib::moves {
 	using namespace positions;

--- a/zathras_lib/src/Move_generator_pregen.cpp
+++ b/zathras_lib/src/Move_generator_pregen.cpp
@@ -1,13 +1,13 @@
-#include "move_generator.h"
+#include "Move_generator.h"
 
 #include <bitset>
 #include <utility>
 #include <vector>
 
-#include "position.h"
-#include "square.h"
-#include "piece.h"
-#include "bitboard.h"
+#include "Position.h"
+#include "Square.h"
+#include "Piece.h"
+#include "Bitboard.h"
 
 
 namespace zathras_lib::moves {

--- a/zathras_lib/src/Move_state.cpp
+++ b/zathras_lib/src/Move_state.cpp
@@ -4,7 +4,7 @@
  *  Created on: 02.12.2017
  *      Author: nczempin
  */
-#include "move_state.h"
+#include "Move_state.h"
 namespace zathras_lib::moves {
 
 	Move_state::Move_state() :en_passant_square(-1), cleared_kingside_castling(false), cleared_queenside_castling(false) {

--- a/zathras_lib/src/Piece.cpp
+++ b/zathras_lib/src/Piece.cpp
@@ -5,7 +5,7 @@
  *      Author: nczempin
  */
 
-#include "piece.h"
+#include "Piece.h"
 namespace positions {
 	Piece::Piece()
 	{

--- a/zathras_lib/src/Position.cpp
+++ b/zathras_lib/src/Position.cpp
@@ -12,13 +12,13 @@
 #include <cassert>
 #include <stack>
 
-#include "position.h"
-#include "square.h"
-#include "piece.h"
+#include "Position.h"
+#include "Square.h"
+#include "Piece.h"
 #include "typedefs.h"
-#include "move_generator.h"
+#include "Move_generator.h"
 
-#include "bitboard.h"
+#include "Bitboard.h"
 
 
 namespace positions {

--- a/zathras_lib/src/Position.h
+++ b/zathras_lib/src/Position.h
@@ -12,10 +12,10 @@
 #include <stack>
 
 #include "typedefs.h"
-#include "move.h"
-#include "move_state.h"
-#include "bitboard.h"
-#include "piece.h"
+#include "Move.h"
+#include "Move_state.h"
+#include "Bitboard.h"
+#include "Piece.h"
 
 
 namespace positions {

--- a/zathras_lib/src/Position_fen.cpp
+++ b/zathras_lib/src/Position_fen.cpp
@@ -1,4 +1,4 @@
-#include "position.h"
+#include "Position.h"
 namespace positions {
 	Position Position::create_position(const string& fen) {
 		Position position;

--- a/zathras_lib/src/Position_print.cpp
+++ b/zathras_lib/src/Position_print.cpp
@@ -1,4 +1,4 @@
-#include "position.h"
+#include "Position.h"
 
 namespace positions {
 

--- a/zathras_lib/src/Searcher.cpp
+++ b/zathras_lib/src/Searcher.cpp
@@ -5,9 +5,9 @@
 #include <cassert>
 #include <cstdlib>
 
-#include "searcher.h"
-#include "evaluator.h"
-#include "move.h"
+#include "Searcher.h"
+#include "Evaluator.h"
+#include "Move.h"
 
 
 #include "misc.h"

--- a/zathras_lib/src/Searcher.h
+++ b/zathras_lib/src/Searcher.h
@@ -4,10 +4,10 @@
 #include <climits>
 
 
-#include "move.h"
-#include "position.h"
-#include "move_generator.h"
-//#include "info.h"
+#include "Move.h"
+#include "Position.h"
+#include "Move_generator.h"
+//#include "Info.h"
 
 using namespace zathras_lib::moves;
 class Searcher

--- a/zathras_lib/src/Square.cpp
+++ b/zathras_lib/src/Square.cpp
@@ -9,7 +9,7 @@
 #include <cassert>
 #include <bitset>
 
-#include "square.h"
+#include "Square.h"
 #include "typedefs.h"
 
 namespace positions {

--- a/zathras_lib/src/typedefs.h
+++ b/zathras_lib/src/typedefs.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <array>
 #include <functional>
-#include "square.h"
+#include "Square.h"
 
 
 using namespace std;

--- a/zathras_lib/src/zathras_lib.h
+++ b/zathras_lib/src/zathras_lib.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "square.h"
+#include "Square.h"
 #include <string>
 const std::string VERSION = "0.0.5";
 


### PR DESCRIPTION
## Summary
- update include directives to match correct header filename casing
- ensure build passes on case-sensitive filesystems

## Testing
- `make test` *(fails: Positions namespace not found)*
- `make`