### PR TITLE
Fix CI badge path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zathras
 
-[![CI](https://github.com/<owner>/<repo>/actions/workflows/ci.yml/badge.svg)](https://github.com/<owner>/<repo>/actions/workflows/ci.yml)
+[![CI](https://github.com/nczempin/zathras/actions/workflows/ci.yml/badge.svg)](https://github.com/nczempin/zathras/actions/workflows/ci.yml)
 
 I wanted to get more seriously into more modern C++, bitboards, and eventually a multithreaded chess engine.
 


### PR DESCRIPTION
## Summary
- replace badge placeholder with real repo path

## Testing
- `git status --short`
