### PR TITLE
Fix Makefile clean rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ test: $(TEST_BIN)
 
 .PHONY: clean
 clean:
-	rm -f $(BIN) $(OBJ) $(LIB)
+	rm -f $(BIN) $(OBJ) $(LIB) $(TEST_BIN)


### PR DESCRIPTION
## Summary
- extend `clean` rule in Makefile so that run_tests executable is removed

## Testing
- `make clean && make && make test`
- `cppcheck --enable=warning --inconclusive --quiet src zathras_lib/src tests/unit` *(fails: command not found)*
