### PR TITLE
Fix FEN delimiter in stockfish script

### DIFF
--- a/stock.sh
+++ b/stock.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cat <<EOF | stockfish
-position fen r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq – 1 1
+position fen r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 1 1
 position startpos
 perft 6
 EOF


### PR DESCRIPTION
## Summary
- fix invalid FEN string in `stock.sh` by replacing the en dash with a hyphen

## Testing
- `make`
- `make test`
- `cppcheck` *(fails: command not found)*