### PR TITLE
Add zathras binary to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,6 @@ UserInterfaceState.xcuserstate
 
 # Build artifacts
 libzathras.a
-run_tests
+zathras
+run_tests*
 


### PR DESCRIPTION
## Summary
- add `zathras` and generalize `run_tests` entry in `.gitignore`

## Testing
- `make test`
- `cppcheck` *(fails: command not found)*