### PR TITLE
Update gitignore for zathras binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,5 @@ UserInterfaceState.xcuserstate
 # Build artifacts
 libzathras.a
 run_tests
+zathras
 


### PR DESCRIPTION
## Summary
- ignore the `zathras` executable produced by `make`

Checked history for stray binaries and found none.

## Testing
- `git rev-list --objects --all | grep -E '\.(o|a|exe)$' | head`
