### PR TITLE
Add one-command build and cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,33 @@
 name: CI
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y make g++ cppcheck
-      - name: Build
-        run: make
-      - name: Run tests
-        run: make test
-      - name: Static analysis
-        run: cppcheck --enable=warning --inconclusive --quiet src zathras_lib/src tests/unit
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: choco install -y make mingw cppcheck
+      - name: Run pipeline
+        run: python run.py
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          name: zathras-${{ runner.os }}
+          path: zathras.zip

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,11 @@ libzathras.a
 zathras
 run_tests*
 
+
+# Python artifacts
+__pycache__/
+
+# Packaging
+dist/
+zathras.zip
+

--- a/README.md
+++ b/README.md
@@ -8,18 +8,32 @@ engine one day.
 
 ## Requirements
 
-- C++17 compiler (`g++` or `clang++`)
-- `make` and common build tools
+- Python 3
+- C++17 compiler (`g++`, `clang++` or MSVC)
+- `make` on Unix-like systems or Visual Studio on Windows
+- `cppcheck` (optional for extra linting)
 
-## Build
+## Quickstart
+
+From a fresh clone run the following command to build, test and create a
+package archive:
+
+```bash
+python run.py
+```
+
+A `zathras.zip` archive will appear in the project root containing the
+engine executable and static library.
+
+## Manual Build
 
 ```bash
 make        # build the engine and static library
+make test   # run unit tests
 make clean  # remove artifacts
 ```
 
-The `zathras` binary appears in the repository root. Run unit tests with
-`make test`.
+The `zathras` binary appears in the repository root.
 
 ## Run
 

--- a/run.py
+++ b/run.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import subprocess
+import sys
+
+
+def run(cmd):
+    print(f"+ {cmd}")
+    result = subprocess.run(cmd, shell=True)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def build_and_test():
+    if shutil.which('make'):
+        run('make clean')
+        run('make')
+        run('make test')
+        if shutil.which('cppcheck'):
+            run('cppcheck --enable=warning --inconclusive --quiet src zathras_lib/src tests/unit')
+    elif shutil.which('msbuild'):
+        sln = 'zathras.sln'
+        run(f'msbuild {sln} /p:Configuration=Release')
+        exe = os.path.join('Release', 'run_tests.exe')
+        if os.path.exists(exe):
+            run(exe)
+    else:
+        print('No suitable build tool found.')
+        sys.exit(1)
+
+
+def smoke_test():
+    run(f"{sys.executable} tests/smoke/test_basic.py")
+
+
+def package():
+    dist = 'dist'
+    if os.path.exists(dist):
+        shutil.rmtree(dist)
+    os.makedirs(dist, exist_ok=True)
+    exe = 'zathras.exe' if os.name == 'nt' else 'zathras'
+    if os.path.exists(exe):
+        shutil.copy(exe, dist)
+    if os.path.exists('libzathras.a'):
+        shutil.copy('libzathras.a', dist)
+    shutil.make_archive('zathras', 'zip', dist)
+
+
+def main():
+    build_and_test()
+    smoke_test()
+    package()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/smoke/test_basic.py
+++ b/tests/smoke/test_basic.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import sys
+
+
+def main():
+    exe = 'zathras.exe' if os.name == 'nt' else './zathras'
+    proc = subprocess.run(
+        exe,
+        input=b'quit\n',
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+    output = proc.stdout.decode('utf-8', errors='ignore')
+    if proc.returncode != 0:
+        print(output)
+        sys.exit(proc.returncode)
+    assert 'Welcome to Zathras' in output
+    print('Smoke test passed')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python `run.py` helper that builds, tests, smoke-tests and packages
- ignore Python and package artifacts
- include a simple smoke test for the `zathras` binary
- update CI to run the helper on Linux and Windows runners
- document quickstart usage in the README

## Testing
- `git status --short`