### PR TITLE
Remove pragma from Command.cpp

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "Command.h"
 namespace zathras::interface {
 	Command::Command() {


### PR DESCRIPTION
## Summary
- remove stray `#pragma once` line in `Command.cpp`

## Testing
- `bash setup.sh` *(fails: Could not connect to proxy:8080)*
- `make`
- `make test`
- `cppcheck --enable=warning --inconclusive --quiet src zathras_lib/src tests/unit` *(fails: danglingLifetime errors)*