### PR TITLE
Switch tests to real Catch2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,31 @@
 CC=g++
-CFLAGS=-Ofast -g -std=c++17 -Wall -Wextra -pedantic -flto  -fno-builtin -m64 -malign-data=cacheline -march=sandybridge #-fno-inline-small-functions #-fno-omit-frame-pointer
+CXXFLAGS=-Ofast -g -std=c++17 -Wall -Wextra -pedantic -flto -fno-builtin -m64 -malign-data=cacheline -march=sandybridge
+INCLUDES=-Izathras_lib/src -Isrc -Itests/external
 
-BIN= zathras
-SRC=$(wildcard **/*.cpp)
-GAS=$(wildcard *.s)
-NASM=$(wildcard *.asm)
-CPP_OBJ=$(SRC:.cpp=.o)
+BIN=zathras
 
-OBJ=$(CPP_OBJ)
+SRC=$(wildcard src/*.cpp) $(filter-out zathras_lib/src/Bitboard_test.cpp, $(wildcard zathras_lib/src/*.cpp))
+OBJ=$(SRC:.cpp=.o)
+
+TEST_SRC=$(wildcard tests/*.cpp) $(wildcard zathras_lib/src/*_test.cpp)
+TEST_OBJ=$(TEST_SRC:.cpp=.o)
+TEST_BIN=tests/test
 
 all: $(BIN)
 
 $(BIN): $(OBJ)
-	$(CC) -o $(BIN) $(CFLAGS)  $^
-%.o: %.cpp
-	$(CC) -o $@ -c $(CFLAGS) $^
+	$(CC) $(CXXFLAGS) $(INCLUDES) -o $@ $^
 
-.PHONY : clean
-clean :
-	-rm -f $(BIN) $(OBJ)
+%.o: %.cpp
+	$(CC) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(TEST_BIN): $(TEST_OBJ) $(filter-out src/main.o,$(OBJ))
+	$(CC) $(CXXFLAGS) $(INCLUDES) -o $@ $^
+
+.PHONY: clean test
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
+clean:
+	-rm -f $(BIN) $(OBJ) $(TEST_OBJ) $(TEST_BIN)

--- a/tests/bitboard_test.cpp
+++ b/tests/bitboard_test.cpp
@@ -1,0 +1,10 @@
+#include "external/catch_amalgamated.hpp"
+#include "Bitboard.h"
+#include "typedefs.h"
+
+using namespace Positions;
+
+TEST_CASE("Bitboard ffs finds first set bit", "[bitboard]") {
+    REQUIRE(Bitboard::ffs(1ULL) == 1);
+    REQUIRE(Bitboard::ffs(0x10ULL) == 5);
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,6 @@
+#include "external/catch_amalgamated.hpp"
+
+int main(int argc, char* argv[]) {
+    Catch::Session session;
+    return session.run(argc, argv);
+}

--- a/zathras_lib/src/Searcher.h
+++ b/zathras_lib/src/Searcher.h
@@ -7,6 +7,7 @@
 #include "Position.h"
 #include "Move_generator.h"
 //#include "Info.h"
+#include <climits>
 
 using namespace Moves;
 class Searcher


### PR DESCRIPTION
## Summary
- update Makefile so test sources compile
- add Catch2-based test_main and a simple bitboard test
- fix missing <climits> include in Searcher.h

## Testing
- `make test` *(fails: undefined references to Catch symbols)*

------
https://chatgpt.com/codex/tasks/task_e_682910e9d78c8332928449e905a5da1f