### PR TITLE
Clean up compiler warnings for unused parameters and variables

### DIFF
--- a/src/Perft_command.h
+++ b/src/Perft_command.h
@@ -21,7 +21,7 @@
 namespace zathras::interface {
 	class Perft_command : public Abstract_command {
 	public:
-		Perft_command(positions::Position position, size_t depth) :position(position),depth(depth) {}
+		Perft_command(positions::Position position, size_t depth) :depth(depth),position(position) {}
 		virtual ~Perft_command();
 		void execute() override;
 

--- a/src/Uci.h
+++ b/src/Uci.h
@@ -311,7 +311,7 @@ namespace zathras::interface {
 
 			square_t to = static_cast<square_t> (Util::decode_square(moveString.substr(2, 4)));
 			string promotedTo = moveString.substr(4);
-			int promoted_to = 0;
+			[[maybe_unused]] int promoted_to = 0;
 			if (promotedTo != "") {
 				promoted_to = static_cast<piece_t> (Util::decode_piece(promotedTo));
 			}

--- a/zathras_lib/src/Bitboard.cpp
+++ b/zathras_lib/src/Bitboard.cpp
@@ -27,7 +27,6 @@ namespace positions {
 			return;
 		}
 		bb tmp = my_bb;
-		uint8_t coord = 0;
 		uint8_t l = 0;
 		while (tmp!=0) {
 			l = ffs(tmp);

--- a/zathras_lib/src/Move.h
+++ b/zathras_lib/src/Move.h
@@ -99,15 +99,9 @@ namespace zathras_lib::moves {
 
 
 
-	static std::string to_string(Move move) {
-		/*static const string pieces("-PNBRQK");
-		char p = pieces[moving > 0 ? moving : -moving];
-		string moving_string = string(1, p);*/
-
+	inline static std::string to_string(Move move) {
 		std::string retval = positions::Square::mailbox_index_to_square(get_from(move));
 		retval += positions::Square::mailbox_index_to_square(get_to(move));
-
-
 		return retval;
 	}
 

--- a/zathras_lib/src/Move_generator.cpp
+++ b/zathras_lib/src/Move_generator.cpp
@@ -95,7 +95,7 @@ namespace zathras_lib::moves {
 
 		return captured;
 	}
-	bool Move_generator::has_captured_piece(square_t square, int8_t moving) {
+	bool Move_generator::has_captured_piece(square_t square, [[maybe_unused]] int8_t moving) {
 
 		//		const bb pieces = p->pawns | p->knights | p->bishops | p->rooks | p->queens | p->kings;
 
@@ -128,7 +128,7 @@ namespace zathras_lib::moves {
 		return false;
 	}
 
-	void Move_generator::visit_capture_moves(const bb& sub_position, const bitboard_set& all_moves, const move_visitor& f, const bb& other_colour, const int8_t& moving) {
+	void Move_generator::visit_capture_moves(const bb& sub_position, const bitboard_set& all_moves, const move_visitor& f, const bb& other_colour, [[maybe_unused]] const int8_t& moving) {
 		bb position = sub_position;
 		while (position != 0) {
 			const square_t from = square_t(Bitboard::extract_and_remove_square(position)); // TODO handle cast better
@@ -192,7 +192,7 @@ namespace zathras_lib::moves {
 	}
 	void Move_generator::visit_non_capture_moves(const bb& sub_position,
 		const bitboard_set& all_moves, const move_visitor& f,
-		const bb& other_colour, const int8_t& moving) {
+		const bb& other_colour, [[maybe_unused]] const int8_t& moving) {
 		bb position = sub_position;
 		while (position != 0) {
 			const square_t& from = static_cast<square_t>(Bitboard::extract_and_remove_square(position));
@@ -300,7 +300,7 @@ namespace zathras_lib::moves {
 	}
 	void Move_generator::visit_non_capture_ray_moves(const bb& sub_position,
 		const bitboard_set& all_moves, const move_visitor& f,
-		const bb& occupied, const int8_t& moving) {
+		const bb& occupied, [[maybe_unused]] const int8_t& moving) {
 		bb position = sub_position;
 		while (position != 0) {
 			const square_t from = square_t(Bitboard::extract_and_remove_square(position)); // TODO proper cast
@@ -338,7 +338,6 @@ namespace zathras_lib::moves {
 		Bitboard::visit_bitboard(sub_position,
 			[&all_moves, &f, &moving](square_t x) {
 				Bitboard::visit_bitboard(all_moves[x], [&x, &f, &moving](square_t y) {
-					int8_t captured = -98;
 					f(x, y, NONE);
 					});
 
@@ -369,7 +368,7 @@ namespace zathras_lib::moves {
 
 	void Move_generator::visit_pawn_nocaps(const bb& sub_position,
 		const bitboard_set& all_moves, const move_visitor& f,
-		const bb& occupied, const int8_t& moving, const bool& white_to_move) {
+		const bb& occupied, [[maybe_unused]] const int8_t& moving, const bool& white_to_move) {
 		bb position = sub_position;
 		while (position != 0) {
 			const square_t from = square_t(Bitboard::extract_and_remove_square(position));
@@ -435,7 +434,7 @@ namespace zathras_lib::moves {
 		}
 	}
 
-	void Move_generator::attempt_castle(const move_visitor f, const int8_t piece,
+	void Move_generator::attempt_castle(const move_visitor f, [[maybe_unused]] const int8_t piece,
 		const square_t king_square, const int8_t direction) {
 		//1. check if squares between king and rook are free.
 		square_t next_square = square_t(uint8_t(king_square) + direction); //TODO proper cast
@@ -494,9 +493,9 @@ namespace zathras_lib::moves {
 			}
 		}
 	}
-	void Move_generator::f(Move_container& moves, const int8_t moving,
-		const square_t from, const square_t to, const int8_t captured,
-		const int8_t promoted_to) {
+	void Move_generator::f(Move_container& moves, [[maybe_unused]] const int8_t moving,
+		const square_t from, const square_t to, [[maybe_unused]] const int8_t captured,
+		[[maybe_unused]] const int8_t promoted_to) {
 		//bool en_passant_capture = will_be_en_passant(to, moving);
 
 //		moves.add_move(moving, from, to, captured, en_passant_capture, promoted_to);
@@ -534,7 +533,7 @@ namespace zathras_lib::moves {
 		Move_container pseudolegal_moves = generate_pseudolegal_captures(position, depth);
 		Move_container legal_moves;
 		auto moves = pseudolegal_moves.get_moves();
-		for (int i = 0; i < pseudolegal_moves.size(); ++i) {
+		for (size_t i = 0; i < pseudolegal_moves.size(); ++i) {
 			Move move = moves[i];
 			//Position pos2 = position; //copied //TODO inefficient
 			Move_state ms;
@@ -553,7 +552,7 @@ namespace zathras_lib::moves {
 		Move_container pseudolegal_moves = generate_pseudolegal_moves(position, depth);
 		Move_container legal_moves;
 		auto moves = pseudolegal_moves.get_moves();
-		for (int i = 0; i < pseudolegal_moves.size(); ++i) {
+		for (size_t i = 0; i < pseudolegal_moves.size(); ++i) {
 			Move move = moves[i];
 			//Position pos2 = position; //copied //TODO inefficient
 			Move_state ms;

--- a/zathras_lib/src/Position_print.cpp
+++ b/zathras_lib/src/Position_print.cpp
@@ -93,7 +93,6 @@ namespace positions {
 	string Position::mailbox_board_debug_representation(const piece_t board[64]) {
 		string retval;
 		retval += "  +-----------------+\n";
-		const char* symbols = ".PNBRQKpnbrqk*";
 		for (int i = 0; i < 8; ++i) {
 			retval.append(to_string(8 - i));
 			retval.append(" |");

--- a/zathras_lib/src/Searcher.cpp
+++ b/zathras_lib/src/Searcher.cpp
@@ -30,13 +30,9 @@ Move Searcher::findBestmove(move_container_t moves, Position position) {
 	int maxIdDepth = 0;
 	//TODOInfo::seldepth = 0;
 	//TODOInfo::nodes = 0;
-	Move lastIterationBestMove;
 	done = false;
 	deque<Move> lineDown;
-	
-	int movesSize = 0;
 	do {
-		lastIterationBestMove = bestMove;
 		oldBestValue = bestValue;
 		bestValue = -9999999;
 		
@@ -100,7 +96,6 @@ Move Searcher::findBestmove(move_container_t moves, Position position) {
 		//		moves.clear();
 				//static Move emptyMove;
 				//moves.fill(emptyMove);
-		movesSize = 0;
 		
 	} while (!done);
 	return bestMove;
@@ -124,7 +119,7 @@ int Searcher::alphabeta(int depth, Position& position, int alpha, int beta, dequ
 	Move_container mc = mg.generate_legal_moves(position, 1);
 	auto moves = mc.get_moves();// AllMoves(position, moves);
 	int actualMoves = 0;
-	int moveCount = 0;
+	size_t moveCount = 0;
 	for (const Move& newMove : moves) {
 		if (moveCount++ >= mc.size()) {
 			break;
@@ -184,9 +179,6 @@ int Searcher::alphabeta(int depth, Position& position, int alpha, int beta, dequ
 	return alpha;
 }
 
-static bool shouldBeIgnored(Position nextPos, Move newMove, int capture, int capturing) {
-	return false;//TODO (abs(capturing) > abs(capture)) && ((capturing != 3) || (capture != 2)); //TODO: && (!nextPos.enPrise(newMove));
-}
 
 int Searcher::quiescence_alphabeta(int depth, Position& position, int alpha, int beta, deque<Move>& lineUp) {
 	//ValidFlag bestMoveValidFlag = new ValidFlag();


### PR DESCRIPTION
## Summary
- Eliminate ~20 compiler warnings by fixing unused parameters, variables, and functions
- Add [[maybe_unused]] attributes for intentionally unused parameters in Move_generator methods
- Remove truly unused variables and functions throughout the codebase
- Fix sign comparison warnings by using appropriate integer types
- Improve code quality while maintaining all functionality

## Test plan
- [x] Compile successfully with only 1 harmless LTO warning remaining (down from ~20 warnings)
- [x] All existing functionality preserved - no behavioral changes
- [x] Code builds cleanly for better development experience

🤖 Generated with [Claude Code](https://claude.ai/code)