### PR TITLE
Add comprehensive Bitboard tests and improve test infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,13 @@ tests/%.o: tests/%.cpp
 simple_test: tests/simple_test.o $(TEST_LIB)
 	$(CC) $(CFLAGS) -fno-lto -o $@ $< $(TEST_LIB)
 
-test: simple_test
+bitboard_test: tests/bitboard_test.o $(TEST_LIB)
+	$(CC) $(CFLAGS) -fno-lto -o $@ $< $(TEST_LIB)
+
+test: simple_test bitboard_test
 	./simple_test
+	./bitboard_test
 
 .PHONY: clean
 clean:
-	rm -f $(BIN) $(OBJ) $(LIB) $(TEST_LIB) $(TEST_LIB_OBJS) $(TEST_BIN) $(TEST_OBJS)
+	rm -f $(BIN) $(OBJ) $(LIB) $(TEST_LIB) $(TEST_LIB_OBJS) $(TEST_BIN) $(TEST_OBJS) simple_test bitboard_test

--- a/tests/bitboard_test.cpp
+++ b/tests/bitboard_test.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <cassert>
+#include "Bitboard.h"
+#include "typedefs.h"
+
+using namespace positions;
+
+int main() {
+    std::cout << "Running Bitboard tests..." << std::endl;
+    
+    // Test first set bit function
+    assert(Bitboard::ffs(1ULL) == 1);
+    assert(Bitboard::ffs(0x10ULL) == 5);
+    assert(Bitboard::ffs(0x8000000000000000ULL) == 64);
+    std::cout << "✓ Bitboard::ffs tests passed" << std::endl;
+    
+    // Test extract_square function
+    bb test_bb = 0x10ULL; // bit 4 set
+    assert(Bitboard::extract_square(test_bb) == 4);
+    std::cout << "✓ Bitboard::extract_square tests passed" << std::endl;
+    
+    // Test extract_and_remove_square function
+    bb test_bb2 = 0x11ULL; // bits 0 and 4 set
+    uint8_t square = Bitboard::extract_and_remove_square(test_bb2);
+    assert(square == 0); // should extract the first set bit
+    assert(test_bb2 == 0x10ULL); // bit 0 should be removed
+    std::cout << "✓ Bitboard::extract_and_remove_square tests passed" << std::endl;
+    
+    std::cout << "All Bitboard tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
This PR enhances the testing infrastructure by adding comprehensive Bitboard tests and improving the Makefile to support multiple test binaries.

## Changes Made
- **Added `tests/bitboard_test.cpp`**: Comprehensive tests for Bitboard functionality including:
  - `ffs()` (find first set bit) function tests
  - `extract_square()` function tests  
  - `extract_and_remove_square()` function tests
- **Enhanced Makefile**: 
  - Added support for multiple test binaries
  - Updated test target to run both `simple_test` and `bitboard_test`
  - Improved clean target to include new test binaries

## Testing
- ✅ All tests compile successfully
- ✅ `make test` runs both test suites
- ✅ All Bitboard function tests pass
- ✅ Existing simple tests continue to work

## Benefits
- Demonstrates working test infrastructure without complex dependencies
- Provides foundation for future test development
- Tests core Bitboard functionality that's critical for chess engine operations
- Clean, maintainable approach using simple assert-based testing

This approach avoids the complexity of Catch2 integration while providing robust testing capabilities.