### PR TITLE
ZTH-95 fix incorrect perft test expectations

### DIFF
--- a/scripts/test_comprehensive_perft.sh
+++ b/scripts/test_comprehensive_perft.sh
@@ -128,18 +128,22 @@ test_position "Position 5 - promotion at ply 1" \
     3 62379 \
     4 2103487
 
-# Test 3: En passant position
+# Test 3: En passant position (after 1.e4 — ep square e3 set for black to potentially capture)
+# This is NOT the starting position: white's queen/bishop/king have more mobility
+# Verified values: divide 3 from startpos shows e2e4 -> 600 at depth 2, 13160 at depth 3
 test_position "En passant capture available" \
     "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1" \
     1 20 \
-    2 400 \
-    3 8902
+    2 600 \
+    3 13160
 
 # Test 4: Complex en passant
+# 30 moves: 14 pawn moves + d5d6 + d5xc6ep + 5 knight + 5 bishop + 3 queen + 1 king = 30
+# Verified via divide 1; previous expected 31 was incorrect
 test_position "Complex en passant position" \
     "rnbqkb1r/pp1p1ppp/5n2/2pPp3/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3" \
-    1 31 \
-    2 570
+    1 30 \
+    2 784
 
 # Test 5: Castling test - both sides available
 test_position "Castling availability test" \


### PR DESCRIPTION
## Summary

Corrects two test cases in `scripts/test_comprehensive_perft.sh` that had wrong expected perft values.

## What was wrong

### Test: "En passant capture available"
FEN: `rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1`

This position (after 1.e4) is **not** the starting position. White's queen, bishops, and king have mobility that the starting position lacks. The test assumed depth-2 = 400 (same as startpos), but the correct value is 600.

Verified via: `startpos divide 3` shows e2e4 → 600 nodes at depth 2.

- Depth 2: 400 → **600**
- Depth 3: 8902 → **13160**

### Test: "Complex en passant position"
FEN: `rnbqkb1r/pp1p1ppp/5n2/2pPp3/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3`

Verified via divide 1: white has exactly 30 legal moves, not 31.

- Depth 1: 31 → **30**
- Depth 2: 570 → **784**

## No engine changes

The move generator is correct. All standard perft reference positions pass:
- Starting position depths 1–4 ✓
- Kiwipete depths 1–4 ✓
- Position 4 (promotion intensive) depths 1–4 ✓
- Position 5 (promotion at ply 1) depths 1–4 ✓
- All isolation tests (castling, promotion, en passant, pin) ✓

Total: 23/23 tests pass after this fix.

Closes #95

-- Claude