### PR TITLE
ZTH-113 Rename mailbox_from_bitboard to populate_mailbox_from_bitboards

### DIFF
--- a/src/Uci.h
+++ b/src/Uci.h
@@ -298,7 +298,7 @@ namespace Interface {
 			for (int i = 0; i < 64; ++i) {
 				board[i] = 0;
 			}
-			p.mailbox_from_bitboard(board);
+			p.populate_mailbox_from_bitboards(board);
 			Move m = convert_move(moveString, board, p);
 
 			//TODO make this more elegant

--- a/zathras_lib/src/Position.cpp
+++ b/zathras_lib/src/Position.cpp
@@ -385,7 +385,7 @@ namespace Positions {
 		cout << endl;
 	}
 
-	void Position::mailbox_from_bitboard(piece_t board[64]) const {
+	void Position::populate_mailbox_from_bitboards(piece_t board[64]) const {
 		Bitboard::visit_bitboard(white & pawns, [&board](int x) {
 			board[x] = 1;
 			}
@@ -464,7 +464,7 @@ namespace Positions {
 		for (int i = 0; i < 64; ++i) {
 			mboard[i] = 0;
 		}
-		mailbox_from_bitboard(mboard);
+		populate_mailbox_from_bitboards(mboard);
 		retval += mailbox_board_simple_representation(mboard);
 		retval += mailbox_board_debug_representation(board);
 		retval += "wtm: " + to_string(white_to_move) + "\n";

--- a/zathras_lib/src/Position.h
+++ b/zathras_lib/src/Position.h
@@ -102,7 +102,7 @@ namespace Positions {
 		bitset<4> castling;
 		bool white_to_move = true; //TODO public for now
 
-		void mailbox_from_bitboard(piece_t board[64]) const;
+		void populate_mailbox_from_bitboards(piece_t board[64]) const;
 
 		string debug_board() const;
 


### PR DESCRIPTION
## Summary

Fixes #113

Renames `mailbox_from_bitboard` to `populate_mailbox_from_bitboards` across three files:
- `zathras_lib/src/Position.h` — declaration
- `zathras_lib/src/Position.cpp` — definition and internal call site
- `src/Uci.h` — external call site

The old name was ambiguous about conversion direction and scope. The new name makes both the intent (populating a mailbox array) and the scope (all piece bitboards) explicit.

Build succeeds with only pre-existing warnings.

-- Claude