### PR TITLE
ZTH-87 Fix C++ linting issues from cppcheck and clang-tidy

### DIFF
--- a/src/Abstract_command.h
+++ b/src/Abstract_command.h
@@ -9,7 +9,7 @@ namespace Interface {
 	public:
 		Abstract_command() {}
 		virtual ~Abstract_command() {};
-		virtual void execute() = 0;
+		void execute() override = 0;
 
 	};
 }

--- a/src/Command_receiver.h
+++ b/src/Command_receiver.h
@@ -19,7 +19,7 @@ namespace Interface {
 	public:
 		Command_receiver();
 		virtual ~Command_receiver();
-		void setArguments(vector<string> arguments) {
+		void setArguments(const vector<string>& arguments) {
 			this->arguments = arguments;
 		}
 		vector<string> getArguments() {

--- a/src/Info.h
+++ b/src/Info.h
@@ -24,7 +24,7 @@ namespace Interface {
 			double seconds = (elapsed_seconds.count());
 			Info::nps = static_cast<int>(Info::nodes / seconds);
 		}
-		static void printInfo(int bestValue, int oldBestValue, int idDepth, deque<Move> pv) {
+		static void printInfo(int bestValue, int oldBestValue, int idDepth, const deque<Move>& pv) {
 			cout << "info depth " << idDepth;
 			cout << " seldepth " << Info::seldepth;
 			cout << " currmove " << Moves::to_string(Info::currmove);
@@ -36,11 +36,8 @@ namespace Interface {
 			if (bestValue > 80000) {
 				cout << "mate " << idDepth / 2;
 			}
-			else if (bestValue < 900000) {
-				cout << "cp " << oldBestValue;
-			}
 			else {
-				cout << "cp " << bestValue;
+				cout << "cp " << oldBestValue;
 			}
 			cout << " pv ";
 			for (const Move& m : pv) {

--- a/src/Perft_command.cpp
+++ b/src/Perft_command.cpp
@@ -63,16 +63,6 @@ namespace Interface {
 		return total_result;
 	}
 
-	string Perft_command::format_large_number(int nps) {
-		string nps_wc = to_string(nps);
-		int8_t insert_position = static_cast<int8_t>(nps_wc.length()) - 3;
-		while (insert_position > 0) {
-			nps_wc.insert(insert_position, ",");
-			insert_position -= 3;
-		}
-		return nps_wc;
-	}
-
 	void Perft_command::execute() {
 		cout << "Perft " << to_string(depth) << " for this position:\n";
 		cout << position.print_board();

--- a/src/Perft_command.h
+++ b/src/Perft_command.h
@@ -22,7 +22,6 @@ namespace Interface {
 
 	private:
 		uint64_t perft(uint8_t depth);
-		string format_large_number(int nps);
 
 		shared_ptr<Positions::Position> pp;
 		Moves::Move_generator mg;

--- a/src/Uci.h
+++ b/src/Uci.h
@@ -338,10 +338,6 @@ namespace Interface {
 
 			square_t to = static_cast<square_t> (Util::decodeSquare(move.substr(2, 4)));
 			string promotedTo = move.substr(4);
-			int promoted_to = 0;
-			if (promotedTo != "") {
-				promoted_to = static_cast<piece_t> (Util::decodePiece(promotedTo));
-			}
 
 			
 			move_type_t mt = NONE;

--- a/zathras_lib/src/Evaluator.h
+++ b/zathras_lib/src/Evaluator.h
@@ -618,7 +618,7 @@ namespace Eval {
 		static bool isInsufficientMaterial(PieceCount pc) {
 			return (pc.loneKing()) || (pc.oneLight()) || (pc.isNN());
 		}
-		static bool isEndgame(PieceCount wpc) {
+		static bool isEndgame(const PieceCount& wpc) {
 			//    		if ((isEndGame != null) && (isEndGame.equals(bool.TRUE)))
 			//    			return true;
 			int lightPiecesCount = wpc.knightsCount + wpc.bishopsCount;


### PR DESCRIPTION
## Summary

Fixes #87

Addresses linting issues identified by cppcheck and clang-tidy:

- **Performance**: Pass `vector<string>`, `deque<Move>`, and `PieceCount` by const reference instead of by value (`Command_receiver::setArguments`, `Info::printInfo`, `Evaluator::isEndgame`)
- **Override specifier**: Add `override` to `Abstract_command::execute` pure virtual redeclaration
- **Dead code removal**: Remove unused `Perft_command::format_large_number` (declaration and definition)
- **Unused variable**: Remove `promoted_to` in `Uci::convert_move` (assigned but never read)
- **Always-true condition**: Simplify `Info::printInfo` score output — the `bestValue < 900000` branch was unreachable since `bestValue <= 80000` at that point

Build succeeds with only pre-existing `shouldBeIgnored` warnings.

-- Claude