### PR TITLE
ZTH-114 Rename mailbox_index_to_square to index_to_algebraic

### DIFF
--- a/zathras_lib/src/Move.h
+++ b/zathras_lib/src/Move.h
@@ -86,8 +86,8 @@ int8_t get_captured() const {
 		char p = pieces[moving > 0 ? moving : -moving];
 		string moving_string = string(1, p);*/
 
-		std::string retval = Positions::Square::mailbox_index_to_square(move.get_from());
-		retval += Positions::Square::mailbox_index_to_square(move.get_to());
+		std::string retval = Positions::Square::index_to_algebraic(move.get_from());
+		retval += Positions::Square::index_to_algebraic(move.get_to());
 
 		// Add promotion notation
 		switch (move.get_move_type()) {

--- a/zathras_lib/src/Move_generator.cpp
+++ b/zathras_lib/src/Move_generator.cpp
@@ -248,8 +248,8 @@ namespace Moves {
 	//	const bitboard_set all_moves, const Position position) {
 	//	visit_moves_raw(sub_position, all_moves,
 	//		[](int8_t pc, uint8_t x, uint8_t y, int8_t cpt, int8_t promoted_to) {
-	//			string from = Square::mailbox_index_to_square(x);
-	//			string to = Square::mailbox_index_to_square(y);
+	//			string from = Square::index_to_algebraic(x);
+	//			string to = Square::index_to_algebraic(y);
 	//			cout << from << to << endl;
 	//		}, position.is_white_to_move());
 	//}

--- a/zathras_lib/src/Position.cpp
+++ b/zathras_lib/src/Position.cpp
@@ -372,7 +372,7 @@ namespace Positions {
 		cout << "wtm: " << white_to_move << endl;
 		cout << "ep: ";
 		Bitboard::visit_bitboard(en_passant_square, [](uint8_t y) {
-			cout << Square::mailbox_index_to_square(y) << endl;
+			cout << Square::index_to_algebraic(y) << endl;
 			});
 		cout << endl;
 		cout << "Castling: ";

--- a/zathras_lib/src/Square.cpp
+++ b/zathras_lib/src/Square.cpp
@@ -34,12 +34,12 @@ namespace Positions {
 
 	void Square::print_square(uint8_t x)
 	{
-		string square = mailbox_index_to_square(x);
+		string square = index_to_algebraic(x);
 		cout << x << " = " << square << endl;
 
 	}
 
-	string Square::mailbox_index_to_square(uint8_t x)
+	string Square::index_to_algebraic(uint8_t x)
 	{
 		const char column = 'a' + x % 8;
 		string columnString(1, column);

--- a/zathras_lib/src/Square.h
+++ b/zathras_lib/src/Square.h
@@ -40,7 +40,11 @@ namespace Positions {
 		static void init_squares();
 		virtual ~Square();
 		static void print_square(uint8_t square);
-		static std::string mailbox_index_to_square(uint8_t x);
+		// Converts a square index to algebraic notation (e.g. 0->"a1", 63->"h8").
+		// Uses standard file ordering (a=0). Note: the engine internally stores
+		// positions with flipped files (7-file), so bitboard bit positions will
+		// not match the algebraic output of this function for files.
+		static std::string index_to_algebraic(uint8_t x);
 		
 		static void set_square(bitset<64> & bs, square_t to);
 		static void clear_square(bitset<64> & bs, square_t to);


### PR DESCRIPTION
## Summary

Fixes #114

Renames `mailbox_index_to_square` to `index_to_algebraic` across five files and adds a doc comment explaining the coordinate convention.

The old name was misleading: it implied mailbox indexing, but the function uses standard file ordering (`a=0`), while the engine internally stores positions with flipped files (`7-file`). This caused confusion during debugging of issue #109 where bitboard bit positions didn't match the algebraic output.

The new name `index_to_algebraic` is neutral about the internal representation and the doc comment explicitly warns about the coordinate flipping.

Files changed:
- `zathras_lib/src/Square.h` — declaration renamed + doc comment added
- `zathras_lib/src/Square.cpp` — definition and call site renamed
- `zathras_lib/src/Move.h` — call sites renamed
- `zathras_lib/src/Position.cpp` — call site renamed
- `zathras_lib/src/Move_generator.cpp` — commented-out call sites renamed

Build succeeds with only pre-existing warnings.

-- Claude