### PR TITLE
ZTH-114 Add bitboard_index_to_square for correct debug output

### DIFF
--- a/zathras_lib/src/Position.cpp
+++ b/zathras_lib/src/Position.cpp
@@ -372,7 +372,7 @@ namespace Positions {
 		cout << "wtm: " << white_to_move << endl;
 		cout << "ep: ";
 		Bitboard::visit_bitboard(en_passant_square, [](uint8_t y) {
-			cout << Square::mailbox_index_to_square(y) << endl;
+			cout << Square::bitboard_index_to_square(y) << endl;
 			});
 		cout << endl;
 		cout << "Castling: ";

--- a/zathras_lib/src/Square.cpp
+++ b/zathras_lib/src/Square.cpp
@@ -39,9 +39,25 @@ namespace Positions {
 
 	}
 
+	// Converts a standard index (a1=0, b1=1, ..., h8=63) to algebraic notation.
+	// NOTE: The engine internally uses file-flipped indices (7-file+rank*8),
+	// so raw bitboard positions will display incorrectly with this function.
+	// Use bitboard_index_to_square() for internal/bitboard indices.
 	string Square::mailbox_index_to_square(uint8_t x)
 	{
 		const char column = 'a' + x % 8;
+		string columnString(1, column);
+		const char row = '1' + x / 8;
+		string rowString(1, row);
+		string square = columnString + rowString;
+		return square;
+	}
+
+	// Converts an internal file-flipped index to algebraic notation.
+	// Internal layout: index = (7 - file) + rank * 8, so file = 7 - (index % 8).
+	string Square::bitboard_index_to_square(uint8_t x)
+	{
+		const char column = 'a' + (7 - x % 8);
 		string columnString(1, column);
 		const char row = '1' + x / 8;
 		string rowString(1, row);

--- a/zathras_lib/src/Square.h
+++ b/zathras_lib/src/Square.h
@@ -41,6 +41,7 @@ namespace Positions {
 		virtual ~Square();
 		static void print_square(uint8_t square);
 		static std::string mailbox_index_to_square(uint8_t x);
+		static std::string bitboard_index_to_square(uint8_t x);
 		
 		static void set_square(bitset<64> & bs, square_t to);
 		static void clear_square(bitset<64> & bs, square_t to);


### PR DESCRIPTION
## Summary

- Added `bitboard_index_to_square()` to `Square` class that correctly converts internal file-flipped indices (7-file+rank*8) to algebraic notation
- Added documentation comments to `mailbox_index_to_square()` warning about the coordinate system mismatch
- Updated en passant debug output in `Position.cpp` to use the new function

Fixes #114

## Test plan

- [x] Perft 3 from startpos returns 8902 (correct)
- [x] Build succeeds with no new warnings
- [ ] Reviewer verifies the file-flip formula matches engine internals

-- Claude